### PR TITLE
fix: invert track direction in blind car game

### DIFF
--- a/src/blind-corner/script.js
+++ b/src/blind-corner/script.js
@@ -71,7 +71,7 @@ function generateTrackSegments() {
 
 // Get track segment at a given y position
 function getTrackSegment(y) {
-  const index = Math.floor((y + trackOffset) / 2);
+  const index = Math.floor((y - trackOffset) / 2);
   if (index < 0 || index >= trackSegments.length) {
     return null;
   }
@@ -99,7 +99,7 @@ function drawTrack() {
   // Draw track segments
   for (let i = 0; i < trackSegments.length; i++) {
     const segment = trackSegments[i];
-    const y = segment.y - trackOffset;
+    const y = segment.y + trackOffset;
 
     if (y < -10 || y > canvas.height + 10) continue;
 


### PR DESCRIPTION
The track now moves down to create the illusion of the car moving forward (up), as expected by players. Previously, the logic was inverted.

## Changes
- Updated drawTrack() to add trackOffset instead of subtracting it
- Updated getTrackSegment() to subtract trackOffset instead of adding it

Fixes #2

---
Generated with [Claude Code](https://claude.ai/code)